### PR TITLE
feat: 新增源码编译容器部署配置文件

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM anapsix/alpine-java:8_server-jre_unlimited
+FROM eclipse-temurin:8-jre
 
 RUN mkdir -p /AJ-Report
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM anapsix/alpine-java:8_server-jre_unlimited
+
+RUN mkdir -p /AJ-Report
+
+WORKDIR /AJ-Report
+
+COPY ./build/aj-report-1.1.0.RELEASE /AJ-Report
+
+CMD /AJ-Report/bin/start.sh && tail -f /AJ-Report/logs/aj-report.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.8"
+
+services:
+  aj-report:
+    container_name: aj-report
+    image: aj-report
+    restart: always
+    ports:
+      - 9095:9095
+    environment:
+      TZ: "Asia/Shanghai"
+    build:
+      context: .
+    volumes:
+      - ./build/aj-report-logs:/AJ-Report/logs
+    depends_on:
+      - aj-report-mysql
+
+  aj-report-mysql:
+    container_name: aj-report-mysql
+    image: mysql:5.7
+    restart: always
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: 123456
+      TZ: "Asia/Shanghai"
+    command:
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_general_ci
+      --explicit_defaults_for_timestamp=true
+      --lower_case_table_names=1
+      --max_allowed_packet=128M
+    volumes:
+      - ./build/aj-report-mysql:/var/lib/mysql


### PR DESCRIPTION
0. 部署主机需预安装docker及docker compose。
1. 参照技术文档[快速入门>源码部署](https://ajreport.beliefteam.cn/report-doc/guide/quicklySource.html)章节，解压缩产生build/aj-report-xxxx目录。
2. 修改数据库连接，MySQL JDBC url指向部署主机，root密码默认为123456。
3. 使用docker-compose up -d命令启动程序即可。
4. MySQL数据存储在目录build/aj-report-mysql。
5. AJ-Report执行日志存储在目录build/aj-report-logs。